### PR TITLE
Added option to specify samtools path

### DIFF
--- a/src/bash/bismark-deduplicate.sh
+++ b/src/bash/bismark-deduplicate.sh
@@ -47,7 +47,7 @@ if $parallel_mode; then
 				# Sleep up to 10 seconds
 				echo ""
 				echo "Running Bismark deduplication report for $label ..." 2>&1 | tee -a $tmp_clog/bismark-deduplicate.log
-				ded=$($bismark_path/deduplicate_bismark $deduplicate --bam  "$2" --output_dir $tmp_dide/ 2>&1 | tee -a $tmp_dide/$label.log )
+				ded=$($bismark_path/deduplicate_bismark $deduplicate --bam  "$2" --samtools_path $samtools_path --output_dir $tmp_dide/ 2>&1 | tee -a $tmp_dide/$label.log )
 				echo $2 >> $tmp_dide/list-finished.lst;   
 				sed -n -e 15p  -e 18,22p $tmp_dide/$label.log
 				echo "---------------------------------------------------------------"
@@ -69,7 +69,7 @@ else
 				label=$(echo $(echo $bamfile | sed 's/.*\///') | sed -e 's/.bam//g')
 				echo ""
 				echo "Running Bismark deduplication report for $label ..." 
-				ded=$($bismark_path/deduplicate_bismark	$deduplicate --bam $bamfile --output_dir $tmp_dide/ 2>&1 | tee -a $tmp_dide/$label.log)
+				ded=$($bismark_path/deduplicate_bismark	$deduplicate --bam $bamfile --samtools_path $samtools_path --output_dir $tmp_dide/ 2>&1 | tee -a $tmp_dide/$label.log)
 				runtime=$((($(date +%s)-$start)/60))
 				echo $bamfile >> $tmp_dide/list-finished.lst;
 				sed -n -e 15p  -e 18,22p $tmp_dide/$label.log;

--- a/src/bash/bismark-mapper-pair-parallel.sh
+++ b/src/bash/bismark-mapper-pair-parallel.sh
@@ -42,11 +42,11 @@ if $run_pair_bismark; then
 			if $nucleotide; then
 				echo "Nucleotide coverage is enabled." >> $tmp_clog/bismark-mapper.log  
 				echo "Running bismark for $file1 , $file2 and $file3 , $file4 ..." >> $tmp_clog/bismark-mapper.log
-				result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
+				result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
 			else
 				echo "Nucleotide coverage is disabled." >> $tmp_clog/bismark-mapper.log
 				echo "Running bismark for $file1 , $file2 and $file3 , $file4 ..." >> $tmp_clog/bismark-mapper.log
-				result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+				result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 			fi	
 			echo $tmp_fq/$file1 >> $tmp_bismap/list-finished.lst;
 			echo $tmp_fq/$file2 >> $tmp_bismap/list-finished.lst;
@@ -76,11 +76,11 @@ else
 		if $nucleotide; then
 			echo "Nucleotide coverage is enabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log 
 			echo "Running bismark for $file1 and $file2 ..." >> $tmp_clog/bismark-mapper.log
-			result=$($bismark_path/bismark -N 1 -L 32 --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
+			result=$($bismark_path/bismark -N 1 -L 32 --samtools_path $samtools_path --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
 		else
 			echo "Nucleotide coverage is disabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
 			echo "Running bismark for $file1 and $file2 ..." >> $tmp_clog/bismark-mapper.log
-			result=$($bismark_path/bismark -N 1 -L 32 --parallel $bis_parallel -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+			result=$($bismark_path/bismark -N 1 -L 32 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 		fi
 		echo $tmp_fq/$file1 >> $tmp_bismap/list-finished.lst;
 		echo $tmp_fq/$file2 >> $tmp_bismap/list-finished.lst;

--- a/src/bash/bismark-mapper-pair.sh
+++ b/src/bash/bismark-mapper-pair.sh
@@ -38,11 +38,11 @@ if $run_pair_bismark; then
 			if $nucleotide; then
 				echo "-- Nucleotide coverage is enabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log  
 				echo "-- Running bismark for $file1 , $file2 and $file3 , $file4 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-				result=$($bismark_path/bismark -s 0 -u 0 -n 0 -l 20 --parallel $bis_parallel -p $Nthreads  --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
+				result=$($bismark_path/bismark -s 0 -u 0 -n 0 -l 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads  --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
 			else
 				echo "-- Nucleotide coverage is disabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
 				echo "-- Running bismark for $file1 , $file2 and $file3 , $file4 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-				result=$($bismark_path/bismark -s 0 -u 0 -n 0 -l 20 --parallel $bis_parallel  -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+				result=$($bismark_path/bismark -s 0 -u 0 -n 0 -l 20 --samtools_path $samtools_path --parallel $bis_parallel  -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 $tmp_fq/$file2 -2 $tmp_fq/$file3 $tmp_fq/$file4 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 			fi	
 			echo $tmp_fq/$file1 >> $tmp_bismap/list-finished.lst;
 			echo $tmp_fq/$file2 >> $tmp_bismap/list-finished.lst;
@@ -68,11 +68,11 @@ else
 			if $nucleotide; then
 				echo "-- Nucleotide coverage is enabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log 
 				echo "-- Running bismark for $file1 and $file2 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-				result=$($bismark_path/bismark -N 1 -L 32 --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
+				result=$($bismark_path/bismark -N 1 -L 32 --samtools_path $samtools_path --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
 			else
 				echo "-- Nucleotide coverage is disabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
 				echo "-- Running bismark for $file1 and $file2 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-				result=$($bismark_path/bismark -N 1 -L 32 --parallel $bis_parallel -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+				result=$($bismark_path/bismark -N 1 -L 32 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $genome_ref -1 $tmp_fq/$file1 -2 $tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 			fi
 			echo $tmp_fq/$file1 >> $tmp_bismap/list-finished.lst;
 			echo $tmp_fq/$file2 >> $tmp_bismap/list-finished.lst;

--- a/src/bash/bismark-mapper-scBS-Seq.sh
+++ b/src/bash/bismark-mapper-scBS-Seq.sh
@@ -61,11 +61,11 @@ if $pairs_mode; then # check if runing in single or parallel
 							if $nucleotide; then
 								echo "-- Nucleotide coverage is enabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log 
 								echo "-- Running bismark for $file1 and $file2 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome $directional  $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
+								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome $directional  $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
 							else
 								echo "-- Nucleotide coverage is disabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
 								echo "-- Running bismark for $file1 and $file2 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome $directional $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $directional $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 							fi
 							echo $tmp_fq/$file1 >> $tmp_bismap/list-finished.lst;
 							echo $tmp_fq/$file2 >> $tmp_bismap/list-finished.lst;
@@ -91,11 +91,11 @@ if $pairs_mode; then # check if runing in single or parallel
 							if $nucleotide; then
 								echo "-- Nucleotide coverage is enabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log 
 								echo "-- Running bismark for $file1 and $file2 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome  $directional $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
+								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel  -p $Nthreads --nucleotide_coverage --genome  $directional $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log ) 
 							else
 								echo "-- Nucleotide coverage is disabled." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
 								echo "-- Running bismark for $file1 and $file2 ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome $directional  $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+								result=$($bismark_path/bismark -s 0 -u 0 -n 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $directional  $genome_ref --bowtie2 --pbat --se $tmp_fq/$file1,$tmp_fq/$file2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 							fi
 							echo $tmp_fq/$file1 >> $tmp_bismap/list-finished.lst;
 							echo $tmp_fq/$file2 >> $tmp_bismap/list-finished.lst;
@@ -173,11 +173,11 @@ else
 								if $nucleotide; then
 									echo "-- Nucleotide coverage is enabled." 
 									echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome  $directional  $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
+									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome  $directional  $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
 								else
 									echo "-- Nucleotide coverage is disabled." 
 									echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome  $directional  $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome  $directional  $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 								fi
 								echo $2 >> $tmp_bismap/list-finished.lst;			
 
@@ -200,11 +200,11 @@ else
 								if $nucleotide; then
 									echo "-- Nucleotide coverage is enabled." 
 									echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome  $directional  $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
+									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome  $directional  $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
 								else
 									echo "-- Nucleotide coverage is disabled." 
 									echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome  $directional  $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+									result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome  $directional  $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 								fi
 								#---------------------------------------------------------------------------
 								echo $fq >> $tmp_bismap/list-finished.lst;

--- a/src/bash/bismark-mapper.sh
+++ b/src/bash/bismark-mapper.sh
@@ -41,11 +41,11 @@ if $parallel_mode; then
 				if $nucleotide; then
 					echo "-- Nucleotide coverage is enabled." 
 					echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
+					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
 				else
 					echo "-- Nucleotide coverage is disabled." 
 					echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $genome_ref -q $2 -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 				fi
 				echo $2 >> $tmp_bismap/list-finished.lst;			
 
@@ -68,11 +68,11 @@ if $parallel_mode; then
 				if $nucleotide; then
 					echo "-- Nucleotide coverage is enabled." 
 					echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
+					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --nucleotide_coverage --genome $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log )
 				else
 					echo "-- Nucleotide coverage is disabled." 
 					echo "-- Running bismark for $label ..." 2>&1 | tee -a $tmp_clog/bismark-mapper.log
-					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --parallel $bis_parallel -p $Nthreads --genome $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
+					result=$($bismark_path/bismark -s 0 -u 0 -N 0 -L 20 --samtools_path $samtools_path --parallel $bis_parallel -p $Nthreads --genome $genome_ref -q $fq -o $tmp_bismap/ 2>&1 | tee -a $tmp_bismap/$label.log)
 				fi
 				#---------------------------------------------------------------------------
 				echo $fq >> $tmp_bismap/list-finished.lst;

--- a/src/bash/bismark-meth-extractor.sh
+++ b/src/bash/bismark-meth-extractor.sh
@@ -55,7 +55,7 @@ if $parallel_mode; then
 			echo "Running Bismark meth extractor for $2" 2>&1 | tee -a $tmp_clog/bismark-meth-extract.log
 			tmp=$(echo "$2" | sed 's/.*\///')
 			label=$(echo ${tmp%%.*})
-	        bis_extractor=$($bismark_path/bismark_methylation_extractor $deduplicate  --bedGraph --CX --cytosine_report --parallel $bis_parallel --buffer_size $buf_size"G" --genome_folder $genome_ref "$2" -o $tmp_dme/ 2>&1 | tee -a $tmp_dme/$label.log )
+	        bis_extractor=$($bismark_path/bismark_methylation_extractor $deduplicate  --bedGraph --CX --cytosine_report --samtools_path $samtools_path --parallel $bis_parallel --buffer_size $buf_size"G" --genome_folder $genome_ref "$2" -o $tmp_dme/ 2>&1 | tee -a $tmp_dme/$label.log )
 			#cat  $tmp_dme/$label.deduplicated_splitting_report.txt 2>&1 | tee -a $tmp_clog/bismark-meth-extract.log
 			echo $2 >> $tmp_dme/list-finished.lst;
 			echo "-- Moving Cx-reports to the $tmp_cx_report folder." 
@@ -83,7 +83,7 @@ else
 			echo "-- Running Bismark meth extractor for $bm" 
 			tmp=$(echo $bm | sed 's/.*\///')
 			label=$(echo ${tmp%%.*})
-	        bis_extractor=$($bismark_path/bismark_methylation_extractor $deduplicate  --bedGraph --CX --cytosine_report --parallel $bis_parallel --buffer_size $buf_size"G" --genome_folder $genome_ref $bm -o $tmp_dme/ 2>&1 | tee -a $tmp_dme/$label.log )
+	        bis_extractor=$($bismark_path/bismark_methylation_extractor $deduplicate  --bedGraph --CX --cytosine_report --samtools_path $samtools_path --parallel $bis_parallel --buffer_size $buf_size"G" --genome_folder $genome_ref $bm -o $tmp_dme/ 2>&1 | tee -a $tmp_dme/$label.log )
 			#cat  $tmp_dme/$label.deduplicated_splitting_report.txt 2>&1 | tee -a $tmp_clog/bismark-meth-extract.log
 			echo $bm >> $tmp_dme/list-finished.lst;
 			echo "-- Moving Cx-reports to the $tmp_cx_report folder." 

--- a/src/bash/path-export.sh
+++ b/src/bash/path-export.sh
@@ -5,23 +5,20 @@ com1=$(awk '/^\[/ { } /=/ { print $0 }' config/pipeline.conf > $curr_dir/tmp.con
 
 
 if [ ! -d $bismark_path ]; then
-	echo "Error: we require Bismark! but its not installed. see the configuration file 'config.cfg'"
+	echo "Error: we require Bismark! But it's not installed. See the configuration file 'config.cfg'."
 	exit 1
 fi
 
 if ! [ -x "$(command -v bowtie2)" ]; then
-  echo "Error: we could't find 'Bowtie2' in your PATH. see the configuration file 'config.cfg'"
+  echo "Error: we couldn't find 'Bowtie2' in your PATH. See the configuration file 'config.cfg'."
   exit 1
  else 
- 	sam=$(echo $(command -v bowtie2)) 
+ 	bow=$(echo $(command -v bowtie2)) 
  	echo $bow
 	export PATH="$PATH:$bow"
 fi
 
-if ! [ -x "$(command -v samtools)" ]; then
-  echo "Error: we could't find 'samtools' in your PATH. see the configuration file 'config.cfg'"
+if ! [ -x "$(command -v $samtools_path)" ]; then
+  echo "Error: we couldn't find 'samtools' in the specified location. See the configuration file 'config.cfg'."
   exit 1
- else 
- 	sam=$(echo $(command -v samtools)) 
-	export PATH="$PATH:$sam"
 fi

--- a/src/py/configuration.py
+++ b/src/py/configuration.py
@@ -792,12 +792,50 @@ def bismark_path():
 
     else:
         pass
-
+    
+    samtoolsCheck()
     bedtoolsCheck()
 
     message(0, "Configuration updated for Bismark Mapper!")
 
 
+def samtoolsCheck():
+    try:
+        title("Please specify the samtools path")
+        if read_config("Bismark", "samtools_path").replace(" ", "") == '':
+            location_bis = subprocess.check_output(['which', 'samtools'])
+            detected = True
+        else:
+            location_bis = read_config("Bismark", "samtools_path")
+            print "You set the location to: " + mcolor(location_bis)
+            detected = False
+        if location_bis != None:
+            if detected:
+                print "Detected samtools program in location: " + mcolor(location_bis)
+            answer = query_yes_no("Do you want to change the location?", None)
+            if answer:
+                location_bis = raw_input("Please enter the samtools file location: ")
+                while not (os.path.isfile(location_bis)):
+                    message(1, "The file does not exist!")
+                    location_bis = raw_input("Please try again: ")
+                replace_config("Bismark", "samtools_path", location_bis)
+                message(4, "--> Configuration updated!")
+            else:
+                replace_config("Bismark", "samtools_path", location_bis)
+                message(3, "We will keep the default value!")
+    except subprocess.CalledProcessError:
+        message(1, "It seems you don't have samtools in your PATH")
+        bismark = raw_input("Please enter the samtools file location: ")
+        while not (os.path.isfile(bismark)):
+            message(1, "The file does not exist!")
+            bismark = raw_input("Please try again: ")
+        replace_config("Bismark", "samtools_path", bismark)
+        message(4, "--> Configuration updated!")
+    except Exception as e:
+        logging.error(traceback.format_exc())
+        message(2, "Something is going wrong... please run again. ")
+
+	
 def bedtoolsCheck():
     try:
         title("Please specify the bedtools path")
@@ -1078,6 +1116,7 @@ def show_config():
     print "     -- Number of Parallel: " + mcolor(read_config("Bismark", "bis_parallel"))+" Threads."
     print "     -- Buffer size: " + mcolor(read_config("Bismark", "buf_size"))+" Gigabyte."
     print "     -- Samtools Path: " + mcolor(read_config("Bismark", "samtools_path"))
+    print "     -- Bedtools Path: " + mcolor(read_config("Bismark", "bedtools_path"))
     print "     -- Intermediate for MethExtractor: " +mcolor(true_false_fields_config(read_config("Bismark", "intermediate_files")))
     print "- Methylation extraction parameters( Only for quick run)"
     print "     -- Minimum read coverage: " + mcolor(read_config("Methimpute", "mincov"))


### PR DESCRIPTION
Although originally the samtools path is shown in the configuration, there was no option to change it (it was assumed to be in the PATH). Being able to specify a path prevents errors on systems where samtools is not directly available in the PATH.